### PR TITLE
make georgian main language

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ import { LanguageRedirect } from "./components/LanguageRedirect";
 const DashboardRedirect = () => {
   const location = useLocation();
   const dashboardPath = location.pathname.replace('/dashboard', '');
-  const fullPath = `/en/dashboard${dashboardPath}${location.search}`;
+  const fullPath = `/ge/dashboard${dashboardPath}${location.search}`;
 
   // Debug logging to see if Flitt redirects reach here
   console.log('🚨 DashboardRedirect triggered:', {

--- a/src/components/LanguageRedirect.tsx
+++ b/src/components/LanguageRedirect.tsx
@@ -5,14 +5,14 @@ import { Navigate } from 'react-router-dom';
 export const LanguageRedirect = () => {
   useEffect(() => {
     // If user accesses root without language, redirect to default language
-    const defaultLang = 'en';
+    const defaultLang = 'ge'; // Georgian as default
     const currentPath = window.location.pathname;
-    
+
     if (currentPath === '/') {
       window.location.replace(`/${defaultLang}`);
     }
   }, []);
 
-  // Navigate to English by default
-  return <Navigate to="/en" replace />;
+  // Navigate to Georgian by default
+  return <Navigate to="/ge" replace />;
 };

--- a/src/components/LanguageRoute.tsx
+++ b/src/components/LanguageRoute.tsx
@@ -26,15 +26,15 @@ export const LanguageRoute = () => {
 
   useEffect(() => {
     const urlLang = lang as UrlLanguageCode;
-    
-    // If no language in URL or invalid language, redirect to default
+
+    // If no language in URL or invalid language, redirect to default (Georgian)
     if (!urlLang || !LANGUAGE_CODES[urlLang]) {
-      const defaultLang = 'en';
+      const defaultLang = 'ge'; // Default to Georgian
       const currentPath = window.location.pathname;
       const newPath = currentPath.startsWith('/en/') || currentPath.startsWith('/ge/') || currentPath.startsWith('/ru/')
         ? currentPath.replace(/^\/[a-z]{2}/, `/${defaultLang}`)
         : `/${defaultLang}${currentPath}`;
-      
+
       navigate(newPath, { replace: true });
       return;
     }
@@ -52,12 +52,12 @@ export const LanguageRoute = () => {
 
 // Helper function to generate language-aware URLs
 export const getLanguageUrl = (path: string, language?: string): string => {
-  const currentLang = language || 'en';
-  const urlLang = URL_LANGUAGE_CODES[currentLang as I18nLanguageCode] || 'en';
-  
+  const currentLang = language || 'ka'; // Default to Georgian
+  const urlLang = URL_LANGUAGE_CODES[currentLang as I18nLanguageCode] || 'ge';
+
   // Remove leading slash if present
   const cleanPath = path.startsWith('/') ? path.slice(1) : path;
-  
+
   // Return the language-prefixed URL
   return `/${urlLang}/${cleanPath}`;
 };

--- a/src/components/PropertyCard.tsx
+++ b/src/components/PropertyCard.tsx
@@ -285,7 +285,7 @@ export const PropertyCard = ({ property }: PropertyCardProps) => {
 
   return (
     <Link
-      to={getLanguageUrl(`/property/${property.id}`)}
+      to={getLanguageUrl(`/property/${property.id}`, i18n.language)}
       className="block h-full transition-all hover:shadow-lg rounded-lg group"
       style={getColorSeparationStyle()}
     >

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -17,9 +17,9 @@ const getLanguageFromUrl = (): string => {
       'ge': 'ka', // Georgian: ge in URL, ka in i18n
       'ru': 'ru'
     };
-    return langMap[urlLang] || 'en';
+    return langMap[urlLang] || 'ka';
   }
-  return 'en'; // fallback
+  return 'ka'; // fallback to Georgian
 };
 
 // Initialize with language from URL
@@ -31,7 +31,7 @@ i18n
   .init({
     resources,
     lng: initialLanguage,
-    fallbackLng: 'en',
+    fallbackLng: 'ka',
     debug: process.env.NODE_ENV === 'development',
     defaultNS: 'common',
     interpolation: {

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -429,7 +429,7 @@ const Home = () => {
 
                       <div className="flex gap-2">
                         <Button asChild className="flex-1 text-xs sm:text-sm" size="sm">
-                          <Link to={getLanguageUrl(`/agencies/${agency.id}`)}>
+                          <Link to={getLanguageUrl(`/agencies/${agency.id}`, i18n.language)}>
                             {t('home.sections.agencies.details')}
                           </Link>
                         </Button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default app language is now Georgian. When no language is set or detected, the app starts in Georgian.
  * Automatic redirects use the Georgian URL prefix (ge) while preserving existing paths and query parameters, including dashboard routes.
  * Links throughout the app (e.g., property and agency pages) are language-aware and retain the current language in the URL.
  * Visiting the root path (/) redirects to the Georgian locale for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->